### PR TITLE
added support for 'long' addresses

### DIFF
--- a/swig/hexrays.i
+++ b/swig/hexrays.i
@@ -795,7 +795,7 @@ class DecompilationFailure(Exception):
 
 def decompile(ea, hf=None):
     
-    if type(ea) == int:
+    if isinstance(ea, (int, long)):
         func = idaapi.get_func(ea)
         if not func: return
     elif type(ea) == idaapi.func_t:


### PR DESCRIPTION
hexrays.decompile() didn't accept some kernel addresses because they are 'long'.
