### PR TITLE
docs: fix simple typo, distibution -> distribution

### DIFF
--- a/build.py
+++ b/build.py
@@ -195,7 +195,7 @@ class MSVCBuilder(BuilderBase):
 
 
 def build_distribution(manifest, distrootdir, ea64, nukeold):
-    """ Create a distibution to a directory and a ZIP file """
+    """ Create a distribution to a directory and a ZIP file """
     # (Re)create the output directory
     if os.path.exists(distrootdir):
         if nukeold:


### PR DESCRIPTION
There is a small typo in build.py.

Should read `distribution` rather than `distibution`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md